### PR TITLE
Allow setting custom properties in service_bus send_message()

### DIFF
--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -315,6 +315,7 @@ impl FromStr for BrokerProperties {
 pub struct SendMessageOptions {
     pub content_type: Option<String>,
     pub broker_properties: Option<SettableBrokerProperties>,
+    pub custom_properties: Option<headers::Headers>,
 }
 
 impl headers::AsHeaders for SendMessageOptions {
@@ -332,6 +333,10 @@ impl headers::AsHeaders for SendMessageOptions {
                 BROKER_PROPERTIES,
                 serde_json::to_string(broker_properties).unwrap().into(),
             ));
+        }
+        
+        if let Some(custom_properties) = &self.custom_properties {
+            headers.extend(custom_properties.clone().into_iter());
         }
 
         headers.into_iter()

--- a/sdk/messaging_servicebus/tests/service_bus.rs
+++ b/sdk/messaging_servicebus/tests/service_bus.rs
@@ -51,6 +51,25 @@ async fn send_message_with_content_type() {
 }
 
 #[tokio::test]
+async fn send_message_with_custom_property_test() {
+    let client = create_client().unwrap();
+    client
+        .send_message(
+            "hello, world!",
+            Some(SendMessageOptions {
+                custom_properties: Some(std::collections::HashMap::from([(
+                    "custom_property_key".into(),
+                    "custom_property_value".into(),
+                )])
+                .into()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("Failed to send message");
+}
+
+#[tokio::test]
 async fn receive_and_delete_message_test() {
     let client = create_client().unwrap();
     send_message_test(); // send message to ensure we can receive something


### PR DESCRIPTION
Following on the recent broker_properties, it'd be nice to be able to set custom properties as well.